### PR TITLE
FEAT-45 added tests for the MetricsGatherer, added testdata for the MetricsGatherer tests, and fixed some small formatting in MetricsGatherer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.jetbrains.intellij") version "1.13.0"
+    id("org.jetbrains.intellij") version "1.13.2"
     id("com.adarshr.test-logger") version "3.2.0"
 }
 

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/MetricsGatherer.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/MetricsGatherer.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 /**
  * This class is used to gather metrics from every method within the currently
- * open IntelliJ Project. If multiple IntellIJ Projects are currently in use,
+ * open IntelliJ Project. If multiple IntelliJ Projects are currently in use,
  * only the first project will be scoured.
  */
 public class MetricsGatherer {
@@ -90,7 +90,6 @@ public class MetricsGatherer {
                 FeaturesVector features = fvWrapper.features;
                 this.methodsMetrics.add(features);
             }
-
         }
     }
 }

--- a/src/test/java/org/jetbrains/research/anticopypaster/utils/MetricsGathererTest.java
+++ b/src/test/java/org/jetbrains/research/anticopypaster/utils/MetricsGathererTest.java
@@ -1,8 +1,75 @@
 package org.jetbrains.research.anticopypaster.utils;
 
-public class MetricsGathererTest {
+import com.intellij.testFramework.fixtures.*;
+import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
+import org.junit.jupiter.api.*;
+
+/**
+ * Test class for the MetricsGatherer. Extends the LightJavaCodeInsightFixtureTestCase,
+ * which is a class that was written for the express purpose of testing IntelliJ
+ * plugins with the full Psi/Project functionality, while reusing the same project in
+ * between tests.
+ */
+public class MetricsGathererTest extends LightJavaCodeInsightFixtureTestCase {
+    // Boolean to ensure the testdata is only added once across the multiple tests
+    private boolean addedTestClass = false;
+
     /**
-     * Test cases to implement: Normal case, one with files that start or end with 'test',
-     * make sure methods are gotten
+     * Gets the path for the testdata.
+     * @return A string of the testdata path
      */
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources/testdata";
+    }
+
+    /**
+     * Overridden from LightJavaCodeInsightFixtureTestCase. Setup now also ensures
+     * the project is initialized fully and adds the testdata to the project.
+     * @throws Exception
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        while (!getProject().isInitialized());
+        if(!addedTestClass) {
+            myFixture.copyDirectoryToProject("", "");
+            addedTestClass = true;
+        }
+    }
+
+    /**
+     * Tests that the list size is what we expect. There are 6 methods in
+     * Calculator.java and 2 in CalculatorTest.java. Only the 6 from
+     * Calculator.java should be gotten.
+     */
+    public void testMetricsListSize() {
+        MetricsGatherer metricsGatherer = new MetricsGatherer();
+        System.out.println("Message = Metrics List Has 6 Methods");
+        Assertions.assertEquals(6 , metricsGatherer.getMethodsMetrics().size());
+    }
+
+    /**
+     * Test to ensure that the arraylist for the MethodMetrics is instantiated
+     * properly and that the MetricsGatherer doesn't crash.
+     */
+    public void testMetricsListNotNull() {
+        MetricsGatherer metricsGatherer = new MetricsGatherer();
+        System.out.println("Message = MetricsList Not Null");
+        Assertions.assertNotNull(metricsGatherer.getMethodsMetrics());
+    }
+
+    /**
+     * Test to ensure that no methods from CalculatorTest made it into the
+     * MetricsGatherer. This is tested by seeing if any of the metrics gotten
+     * have a 1 line method. The only 1 line methods exist in CalculatorTest.java
+     */
+    public void testMetricsInListNoTestMethods() {
+        MetricsGatherer metricsGatherer = new MetricsGatherer();
+        System.out.println("Message = No Single Line Methods Gotten");
+        for(FeaturesVector fv: metricsGatherer.getMethodsMetrics()){
+            float[] arr = fv.buildArray();
+            Assertions.assertNotEquals(1, arr[0]);
+        }
+    }
 }

--- a/src/test/resources/testdata/Calculator.java
+++ b/src/test/resources/testdata/Calculator.java
@@ -1,0 +1,33 @@
+import com.intellij.testFramework.TestDataFile;
+
+@TestDataFile
+public class Calculator{
+    private int currentNumber;
+
+    public Calculator(int number){
+        this.currentNumber = number;
+    }
+
+    public int getCurrentNumber(){
+        return this.currentNumber;
+    }
+    public int add(int toAdd){
+        this.currentNumber += toAdd;
+        return this.currentNumber;
+    }
+
+    public int subtract(int toSubtract){
+        this.currentNumber -= toSubtract;
+        return this.currentNumber;
+    }
+
+    public int multiply(int toMultiply){
+        this.currentNumber = this.currentNumber * toMultiply;
+        return this.currentNumber;
+    }
+
+    public int divide(int toDivide){
+        this.currentNumber = this.currentNumber / toDivide;
+        return this.currentNumber;
+    }
+}

--- a/src/test/resources/testdata/CalculatorTest.java
+++ b/src/test/resources/testdata/CalculatorTest.java
@@ -1,0 +1,8 @@
+import com.intellij.testFramework.TestDataFile;
+
+@TestDataFile
+public class CalculatorTest {
+    public CalculatorTest(){}
+
+    public void testMethodThatShouldntAppear(){}
+}


### PR DESCRIPTION
I would like to point out some additional things that might be considered strange at first glance. The tests do no use the @Test annotation, or any JUnit5 Annotations. When doing this, the tests would end up running twice and have different run conditions in each, making it impossible to actually test. If one set worked, the other would break. 

The solution? Just don't use those annotations. The tests still run, I believe due to the JUnit things already built into the LightJavaCodeInsightFixtureTestCase. Luckily JUnit is backwards compatible as I believe the parts from LightJavaCodeInsightFixtureTestCase are from either JUnit3 or 4.