### PR TITLE
FEAT-56 added in logging of the metrics and patched bug in MetricsGatherer related to readActions

### DIFF
--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -69,14 +69,13 @@ public class RefactoringNotificationTask extends TimerTask {
         while (!eventsQueue.isEmpty()) {
             final PredictionModel model = getOrInitModel();
             try {
-                System.out.println("I made the model");
                 final RefactoringEvent event = eventsQueue.poll();
                 ApplicationManager.getApplication().runReadAction(() -> {
                     DuplicatesInspection.InspectionResult result = inspection.resolve(event.getFile(), event.getText());
                     if (result.getDuplicatesCount() < 2) {
-                        //return;
+                        // This line is commented out due to the getDuplicatesCount method always returning 1.
+                        // return;
                     }
-
                     HashSet<String> variablesInCodeFragment = new HashSet<>();
                     HashMap<String, Integer> variablesCountsInCodeFragment = new HashMap<>();
 

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -23,6 +24,8 @@ import org.jetbrains.research.extractMethod.metrics.MetricCalculator;
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 
 import javax.swing.event.HyperlinkEvent;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Timer;
@@ -44,6 +47,7 @@ public class RefactoringNotificationTask extends TimerTask {
             .getNotificationGroup("Extract Method suggestion");
     private final Timer timer;
     private PredictionModel model;
+    private boolean debugMetrics;
 
 
     public RefactoringNotificationTask(DuplicatesInspection inspection, Timer timer) {
@@ -55,6 +59,7 @@ public class RefactoringNotificationTask extends TimerTask {
         PredictionModel model = this.model;
         if (model == null) {
             model = this.model = new UserSettingsModel(new MetricsGatherer());
+            this.debugMetrics = true;
         }
         return model;
     }
@@ -64,11 +69,12 @@ public class RefactoringNotificationTask extends TimerTask {
         while (!eventsQueue.isEmpty()) {
             final PredictionModel model = getOrInitModel();
             try {
+                System.out.println("I made the model");
                 final RefactoringEvent event = eventsQueue.poll();
                 ApplicationManager.getApplication().runReadAction(() -> {
                     DuplicatesInspection.InspectionResult result = inspection.resolve(event.getFile(), event.getText());
                     if (result.getDuplicatesCount() < 2) {
-                        return;
+                        //return;
                     }
 
                     HashSet<String> variablesInCodeFragment = new HashSet<>();
@@ -84,6 +90,31 @@ public class RefactoringNotificationTask extends TimerTask {
                     FeaturesVector featuresVector = calculateFeatures(event);
 
                     float prediction = model.predict(featuresVector);
+                    if(debugMetrics){
+                        var filepathHolder = new Object(){String filepath = "";};
+                        ApplicationManager.getApplication().runReadAction(() -> {
+                            Project p = ProjectManager.getInstance().getOpenProjects()[0];
+                            String basePath = p.getBasePath();
+                            filepathHolder.filepath = basePath +
+                                    "/.idea/anticopypaster-refactoringSuggestionsLog.log";
+                        });
+
+                        String filepath = filepathHolder.filepath;
+                        try(FileWriter fr = new FileWriter(filepath, true)){
+                            fr.write("\n-----------------------\nNEW COPY/PASTE EVENT:\nPASTED CODE:\n"
+                                    + event.getText());
+
+                            if(prediction > predictionThreshold){
+                                fr.write("\n\nSent Notification: True");
+                            }else{
+                                fr.write("\n\nSent Notification: False");
+                            }
+                            fr.write("\nMETRICS\n");
+                        }catch(IOException ioe){
+
+                        }
+                        model.logInfo(filepath);
+                    }
                     event.setReasonToExtract(AntiCopyPasterBundle.message(
                             "extract.method.to.simplify.logic.of.enclosing.method")); // dummy
 

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -72,9 +72,10 @@ public class RefactoringNotificationTask extends TimerTask {
                 final RefactoringEvent event = eventsQueue.poll();
                 ApplicationManager.getApplication().runReadAction(() -> {
                     DuplicatesInspection.InspectionResult result = inspection.resolve(event.getFile(), event.getText());
+                    // This only triggers if there are duplicates found in multiple methods,
+                    // multiple duplicates in one method doesn't count.
                     if (result.getDuplicatesCount() < 2) {
-                        // This line is commented out due to the getDuplicatesCount method always returning 1.
-                        // return;
+                        return;
                     }
                     HashSet<String> variablesInCodeFragment = new HashSet<>();
                     HashMap<String, Integer> variablesCountsInCodeFragment = new HashMap<>();

--- a/src/main/java/org/jetbrains/research/anticopypaster/models/PredictionModel.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/models/PredictionModel.java
@@ -4,4 +4,7 @@ import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 
 public abstract class PredictionModel {
     public abstract float predict(FeaturesVector featuresVector);
+    public void logInfo(String filepath){
+        throw new UnsupportedOperationException("Method not overridden");
+    }
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/models/UserSettingsModel.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/models/UserSettingsModel.java
@@ -1,5 +1,7 @@
 package org.jetbrains.research.anticopypaster.models;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 import org.jetbrains.research.anticopypaster.utils.MetricsGatherer;
 import org.jetbrains.research.anticopypaster.utils.KeywordsMetrics;
@@ -144,4 +146,13 @@ public class UserSettingsModel extends PredictionModel{
         return shouldNotify ? 1 : 0;
     }
 
+    /**
+     * This function logs all the pertinent metrics info
+     */
+    @Override
+    public void logInfo(String filepath){
+        this.complexityMetrics.logMetric(filepath);
+        this.keywordsMetrics.logMetric(filepath);
+        this.sizeMetrics.logMetric(filepath);
+    }
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/models/UserSettingsModel.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/models/UserSettingsModel.java
@@ -1,15 +1,11 @@
 package org.jetbrains.research.anticopypaster.models;
 
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 import org.jetbrains.research.anticopypaster.utils.MetricsGatherer;
 import org.jetbrains.research.anticopypaster.utils.KeywordsMetrics;
 import org.jetbrains.research.anticopypaster.utils.SizeMetrics;
 import org.jetbrains.research.anticopypaster.utils.ComplexityMetrics;
 import org.jetbrains.research.anticopypaster.utils.Flag;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/ComplexityMetrics.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/ComplexityMetrics.java
@@ -2,8 +2,6 @@ package org.jetbrains.research.anticopypaster.utils;
 
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 
-import java.io.FileWriter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/ComplexityMetrics.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/ComplexityMetrics.java
@@ -1,6 +1,9 @@
 package org.jetbrains.research.anticopypaster.utils;
 
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
+
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,7 +23,8 @@ public class ComplexityMetrics extends Flag{
      */
     private float getComplexityMetricFromFV(FeaturesVector fv){
         if(fv != null){
-            return fv.buildArray()[3];
+            lastCalculatedMetric = fv.buildArray()[3];
+            return lastCalculatedMetric;
         } else {
             return 0;
         }
@@ -42,7 +46,6 @@ public class ComplexityMetrics extends Flag{
         Collections.sort(complexityMetricsValues);
         boxPlotCalculations(complexityMetricsValues);
     }
-
     /**
     Required override function from Flag. This just compares the complexity
     of the passed in FeaturesVector against the correct quartile value 
@@ -55,14 +58,22 @@ public class ComplexityMetrics extends Flag{
             case 0:
                 return false;
             case 1:
-                return fvComplexityValue >= metricQ1; 
+                return fvComplexityValue >= metricQ1;
             case 2:
-                return fvComplexityValue >= metricQ2; 
+                return fvComplexityValue >= metricQ2;
             case 3:
-                return fvComplexityValue >= metricQ3; 
+                return fvComplexityValue >= metricQ3;
             default:
                 return false;
         }
-        
+
+    }
+
+    /**
+     * Easier to use logMetric
+     * @param filepath path to the log file
+     */
+    public void logMetric(String filepath){
+        logMetric(filepath, "Complexity");
     }
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/Flag.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/Flag.java
@@ -1,6 +1,9 @@
 package org.jetbrains.research.anticopypaster.utils;
 
 import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
+
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,6 +18,8 @@ public abstract class Flag{
     protected float metricQ2;
     protected float metricQ3;
 
+    protected float lastCalculatedMetric;
+
     public abstract boolean isFlagTriggered(FeaturesVector featuresVector);
 
     public Flag(List<FeaturesVector> featuresVectorList){
@@ -22,6 +27,7 @@ public abstract class Flag{
         this.metricQ1=0;
         this.metricQ2=0;
         this.metricQ3=0;
+        this.lastCalculatedMetric = -1;
     }
 
     /**
@@ -83,4 +89,34 @@ public abstract class Flag{
         return this.sensitivity;
     }
 
+    /**
+     * This function logs the last known metric and the current threshold
+     * @param filepath path to the log file
+     * @param metricName name of the metric
+     */
+    protected void logMetric(String filepath, String metricName){
+        String threshold = switch (sensitivity) {
+            case (0) -> "Off";
+            case (1) -> Float.toString(this.metricQ1);
+            case (2) -> Float.toString(this.metricQ2);
+            case (3) -> Float.toString(this.metricQ3);
+            default -> "INVALID SENSITIVITY";
+        };
+
+        try(FileWriter fr = new FileWriter(filepath, true)){
+            fr.write("Current " + metricName +
+                    " Threshold, Last Calculated Metric: " +
+                    threshold + ", " + lastCalculatedMetric + "\n");
+        }catch(IOException ioe){
+
+        }
+    }
+
+    /**
+     * Abstract logMetric method which is required to be implemented.
+     * This allows descendants to call the above logMetric with the name
+     * of their metric, and have outside classes only require filepath
+     * @param filepath path to the log file
+     */
+    public abstract void logMetric(String filepath);
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/Flag.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/Flag.java
@@ -5,7 +5,6 @@ import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class Flag{

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/KeywordsMetrics.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/KeywordsMetrics.java
@@ -24,7 +24,8 @@ public class KeywordsMetrics extends Flag{
             for(int i = 16; i<77; i+=2){
                 totalKeywords += fvArray[i];
             }
-            return totalKeywords;
+            lastCalculatedMetric = totalKeywords;
+            return lastCalculatedMetric;
         } else {
             return 0;
         }
@@ -60,15 +61,22 @@ public class KeywordsMetrics extends Flag{
             case 0:
                 return false;
             case 1:
-                return fvKeywordsValue >= metricQ1; 
+                return fvKeywordsValue >= metricQ1;
             case 2:
-                return fvKeywordsValue >= metricQ2; 
+                return fvKeywordsValue >= metricQ2;
             case 3:
-                return fvKeywordsValue >= metricQ3; 
+                return fvKeywordsValue >= metricQ3;
             default:
                 return false;
         }
         
     }
 
+    /**
+     * Easier to use logMetric
+     * @param filepath path to the log file
+     */
+    public void logMetric(String filepath){
+        logMetric(filepath, "Keywords");
+    }
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/SizeMetrics.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/SizeMetrics.java
@@ -34,10 +34,12 @@ public class SizeMetrics extends Flag{
             //divide by zero error, this will just skip making that calculation
             //and return zero regardless of what size of the snippet is
             if(fvArr[11] != (float)0){
-                return fvArr[0]/fvArr[11];
+                lastCalculatedMetric = fvArr[0]/fvArr[11];
+                return lastCalculatedMetric;
             }
         }
-        return 0; 
+        lastCalculatedMetric = 0;
+        return lastCalculatedMetric;
     }
     
     /**
@@ -62,4 +64,11 @@ public class SizeMetrics extends Flag{
         }
     }
 
+    /**
+     * Easier to use logMetric
+     * @param filepath path to the log file
+     */
+    public void logMetric(String filepath){
+        logMetric(filepath, "Size");
+    }
 }


### PR DESCRIPTION
Example of log output: 
```
-----------------------
NEW COPY/PASTE EVENT:
PASTED CODE:
for (PsiMethod method : psiMethods) {
                int startLine = PsiUtil.getNumberOfLine(psiFile, method.getTextRange().getStartOffset());
                int endLine = PsiUtil.getNumberOfLine(psiFile, method.getTextRange().getEndOffset());

                var fvWrapper = new Object() {
                    FeaturesVector features = null;
                };
                ApplicationManager.getApplication().runReadAction(() -> {
                    fvWrapper.features = new
                            MetricCalculator(method, method.getText(), startLine, endLine).getFeaturesVector();
                });

                FeaturesVector features = fvWrapper.features;
                this.methodsMetrics.add(features);
            }

Sent Notification: False
METRICS
Current Complexity Threshold, Last Calculated Metric: 2.0, 16.0
Current Keywords Threshold, Last Calculated Metric: 3.0, 6.0
Current Size Threshold, Last Calculated Metric: 1.0, 0.20547946
```

Note: I added the main logging to the refactoringNotificationTask class so that we could also log the code that was pasted, since we only pass in FeaturesVectors to the models.

Also: This doesn't technically include descriptions of the metrics categories, just the numbers calculated. Didn't think it was worth it to include descriptions of the categories in a log.