### PR TITLE
FEAT-56 added override method to the TestingFlag class for logmetrics that is blank

### DIFF
--- a/src/test/java/org/jetbrains/research/anticopypaster/utils/FlagTest.java
+++ b/src/test/java/org/jetbrains/research/anticopypaster/utils/FlagTest.java
@@ -30,6 +30,11 @@ public class FlagTest {
         public boolean isFlagTriggered(FeaturesVector featuresVector){
             return false;
         }
+
+        @Override
+        public void logMetric(String filepath){
+            // Do nothing just lets tests go
+        }
     }
 
     private TestingFlag testFlag;


### PR DESCRIPTION
You know how when you finally hit merge you always find something you forget? Well I didn't realize that `gradle buildplugin` doesn't run the tests, so I accidentally broke all the tests. This fixes it.